### PR TITLE
fix compilation for macports pHash

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,17 +3,29 @@
     {
       'target_name': 'pHash',
       'sources': [ 'phash.cpp' ],
-      'cflags!': [ '-fno-exceptions' ],
+      'cflags!': [
+        '-fno-exceptions',
+        '<!@(pkg-config --cflags pHash)'
+      ],
       'cflags_cc!': [ '-fno-exceptions' ],
+      'ldflags' : [
+        '<!@(pkg-config --libs-only-L --libs-only-other pHash)'
+      ],
+      'libraries' : [
+        '<!@(pkg-config --libs-only-l pHash)'
+      ],
       'conditions': [
         ['OS=="mac"', {
           'xcode_settings': {
-            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'OTHER_CFLAGS' : [
+              '<!@(pkg-config --cflags pHash)'
+            ]
           }
         }]
       ],
       'link_settings': {
-        'libraries': ['-lpHash']
+        'libraries': ['<!@(pkg-config --libs pHash)']
       },
       "include_dirs" : [
         "<!(node -e \"require('nan')\")"


### PR DESCRIPTION
if pHash is installed in non-standard locations (/opt/local/ on macports), node-gyp will not find it.
I added a couple of pkg-config calls to the binding file to make it work.
I don't think they'll do harm on other platforms.
