### PR TITLE
Fix node12 build issue

### DIFF
--- a/phash.cpp
+++ b/phash.cpp
@@ -81,7 +81,7 @@ class PhashRequest : public Nan::AsyncWorker {
 };
 
 NAN_METHOD(ImageHashAsync) {
-    v8::String::Utf8Value str(info[0]);
+    Nan::Utf8String str(info[0]);
     Nan::Callback *callback = new Nan::Callback(info[1].As<v8::Function>());
     Nan::AsyncQueueWorker(new PhashRequest(callback, string(*str)));
     return;
@@ -140,7 +140,7 @@ class MHPhashRequest : public Nan::AsyncWorker {
 };
 
 NAN_METHOD(MHImageHashAsync) {
-    v8::String::Utf8Value str(info[0]);
+    Nan::Utf8String str(info[0]);
     Nan::Callback *callback = new Nan::Callback(info[1].As<v8::Function>());
     Nan::AsyncQueueWorker(new MHPhashRequest(callback, string(*str)));
     return;


### PR DESCRIPTION
Hi, I've stumble upon this issue trying to install phash-image using node12.

I've noticed that v8 marks the deprecation of v8::String::Utf8Value with a single argument back in node8. 

Latest: https://v8docs.nodesource.com/node-13.2/d4/d1b/classv8_1_1_string_1_1_utf8_value.html

For compatibility across different v8 engines should we use? https://github.com/nodejs/nan/blob/master/doc/v8_misc.md#nanutf8string

Do advice if the fix is not appropriate. Thanks 😀

